### PR TITLE
Adding unit test and support for mixed case unions

### DIFF
--- a/src/TypeShape/TypeShape.fs
+++ b/src/TypeShape/TypeShape.fs
@@ -1498,7 +1498,7 @@ type ShapeFSharpUnionCase<'Union> private (uci : UnionCaseInfo) =
             let underlyingType = properties.[0].DeclaringType
             let allFields = underlyingType.GetFields(allInstanceMembers)
             let mkUnionField (p : PropertyInfo) =
-                let fieldInfo = allFields |> Array.find (fun f -> f.Name = "_" + p.Name || f.Name = p.Name.ToLower())
+                let fieldInfo = allFields |> Array.find (fun f -> f.Name = "_" + p.Name || f.Name.ToLower() = p.Name.ToLower())
                 mkWriteMemberUntyped<'Union> p.Name p [|fieldInfo|]
 
             Array.map mkUnionField properties

--- a/tests/TypeShape.Tests/Tests.fs
+++ b/tests/TypeShape.Tests/Tests.fs
@@ -705,3 +705,13 @@ let ``Should support struct tuples``() =
     testStructTuple (struct(1,"2"))
     testStructTuple (struct(1,"3",2,"4",5,"5",6,"7",8,"9",10))
     testStructTuple (struct(1,"3",2,"4",5,"5",6,"7",8,"9",10,"11",12,"13",14,"15",16,"17"))
+
+type MixedCase = | One of OneId:int
+[<Fact>]
+let ``Should support union with mixed case properties``() =
+    match shapeof<MixedCase> with
+    | Shape.FSharpUnion (:? ShapeFSharpUnion<MixedCase> as shape) ->
+        test <@ shape.UnionCases.Length = 1 @>
+        test <@ shape.UnionCases.[0].Fields.[0].Label = "OneId" @>
+    | _ -> failwith "Unexpected shape"
+    


### PR DESCRIPTION
Noticed that serializer creation in FsPickler was failing on DU types containing members with mixed case labels.  Tracked it down to the difference in `PropertyInfo` and `FieldInfo` reflection. Included here is a unit test with a repro of the issue as well as a fix.