### PR TITLE
Recognize FSharpAsync shape

### DIFF
--- a/tests/TypeShape.Tests/Tests.fs
+++ b/tests/TypeShape.Tests/Tests.fs
@@ -423,6 +423,12 @@ let ``Shape F# Map`` () =
 
     test <@ match shapeof<Map<string, int>> with Shape.FSharpMap s -> s.Accept accepter | _ -> false @>
 
+[<Fact>]
+let ``Shape F# Async`` () =
+    let visitor ty =
+        { new ITypeVisitor<bool> with member __.Visit<'T>() = typeof<'T> = ty }
+
+    test <@ match shapeof<Async<Dictionary<int, string>>> with Shape.FSharpAsync s -> s.Element.Accept (visitor typeof<Dictionary<int, string>>) | _ -> false @>
 
 type Record7 = 
     { 


### PR DESCRIPTION
A mindblowing library, thank you.

Thought it would be handy to support `Async` too, so here it is. I've also had to change the poco and record active patterns, because they'd consider `Async` valid input.

However, I'm not quite sure how to use this elegantly when accessing asynchronous computations is not the main point of using TypeShape. Consider the printer example and wanting to print the resulting value. Either the entire function has to be async (even if the type for which the printer is constructed does not contain any), with 'visitor bodies' of all non-async shapes wrapped in pointless dummy computation expressions (allocating at runtime, to make matters worse) like

```fsharp
| Shape.Int64 -> wrap(fun (b:int64) -> async { return sprintf "%dL" b })
```

or you can resort to `Async.RunSynchronously`, which is a bit of a no-no

```fsharp
| Shape.FSharpAsync s ->
    s.Element.Accept {
        new ITypeVisitor<'T -> string> with
            member __.Visit<'a> () =
                let tp = mkPrinterCached<'a> ctx
                wrap(fun (ts : Async<'a>) -> Async.RunSynchronously ts |> tp) 
    }
```