### PR TITLE
Relax  empty restrictions for recursive types with optional fields

### DIFF
--- a/src/TypeShape/Applications/Empty.fs
+++ b/src/TypeShape/Applications/Empty.fs
@@ -17,8 +17,7 @@ let rec private mkEmptyFunc<'T> () : EmptyFunc<'T> =
         mkEmptyFuncCached<'T> ctx
 
 and private mkEmptyFuncCached<'T> (ctx : TypeGenerationContext) : EmptyFunc<'T> =
-    match ctx.InitOrGetCachedValue<EmptyFunc<'T>>(fun c -> EmptyFunc(fun m -> c.Value.Invoke m)) with
-    | Cached(isValueCreated = false) -> failwithf "Type '%O' does not support empty values." typeof<'T>
+    match ctx.InitOrGetCachedValue<EmptyFunc<'T>>(fun _ -> EmptyFunc(fun m -> failwithf "Type '%O' does not support empty values." typeof<'T>)) with
     | Cached(value = f) -> f
     | NotCached t ->
         let f = mkEmptyFuncAux<'T> ctx

--- a/tests/TypeShape.Tests/Tests.fs
+++ b/tests/TypeShape.Tests/Tests.fs
@@ -670,6 +670,15 @@ let ``Empty should update definitions on new registrations`` () =
 
     test <@ empty<Empty<int> * Empty<string>> = (Empty -1, Empty "otherString") @>
 
+type RecType = RecType of RecType option * RecType list * RecType []
+
+[<Fact>]
+let ``Empty should support types with optional recursive fields`` () =
+    test <@ empty<RecType> = RecType (None, [], [||]) @>
+
+[<Fact>]
+let ``NotEmpty should not support types with optional recursive fields`` () =
+    raises <@ notEmpty<RecType> @>
 
 [<Fact>]
 let ``Shape-Poco should not match primitives`` () =


### PR DESCRIPTION
Fix #51